### PR TITLE
Snapshot v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riescue"
-version = "0.3.0"
+version = "0.3.1"
 description = "RISC-V Directed Test Framework and Compliance Suite"
 readme = "README.md"
 requires-python = ">= 3.9"
@@ -35,4 +35,4 @@ dependencies = [
 riescue = "riescue/"
 
 [project.scripts]
-riescued = "riescue.dtest_framework.runner:main"
+riescued = "riescue.riescued:main"

--- a/riescue/riescued.py
+++ b/riescue/riescued.py
@@ -236,3 +236,11 @@ class RiescueD(CliBase):
                     raise RunnerError(f"WYSIWYG mode failed to find the correct exit value - last line {line}")
 
             print("\nTest \x1b[0;30;42m PASSED \x1b[0m successfully on ISS\n")
+
+
+def main():
+    RiescueD.run_cli()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This fixes issues with installing via pip. `pip install .` should allow users to run with both:


```sh 
python3 -m riescue.riescued
```

Or

```sh
riescued
```